### PR TITLE
ショートカットキーの実装

### DIFF
--- a/src/client/components/Canvas/Canvas.tsx
+++ b/src/client/components/Canvas/Canvas.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { AwsServiceDef } from "../../lib/aws-services";
 import { useCanvasStore } from "../../stores/canvas";
 import type { CanvasNode } from "../../types";
@@ -7,6 +7,8 @@ import EdgeComponent from "./Edge";
 import EdgeCreator from "./EdgeCreator";
 import Group from "./Group";
 import NodeComponent from "./Node";
+
+const DEFAULT_VIEWBOX = { x: 0, y: 0, w: 1200, h: 800 };
 
 export default function Canvas() {
   const {
@@ -164,6 +166,23 @@ export default function Canvas() {
     }
     setEdgeSourceId(null);
   };
+
+  useEffect(() => {
+    const handleZoom = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      setViewBox((prev) => {
+        if (detail === "reset") return { ...DEFAULT_VIEWBOX };
+        const scale = detail === "in" ? 0.8 : 1.25;
+        const cx = prev.x + prev.w / 2;
+        const cy = prev.y + prev.h / 2;
+        const newW = prev.w * scale;
+        const newH = prev.h * scale;
+        return { x: cx - newW / 2, y: cy - newH / 2, w: newW, h: newH };
+      });
+    };
+    window.addEventListener("canvas-zoom", handleZoom);
+    return () => window.removeEventListener("canvas-zoom", handleZoom);
+  }, []);
 
   const sourceNode = edgeSourceId ? data.nodes.find((n) => n.id === edgeSourceId) : null;
 

--- a/src/client/components/Toolbar/ExportButton.tsx
+++ b/src/client/components/Toolbar/ExportButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { canvasDataToDrawio, downloadDrawio } from "../../lib/drawio-generator";
 import { canvasDataToMermaid } from "../../lib/mermaid-generator";
 import { downloadPng, downloadSvg, exportPng, exportSvg } from "../../lib/svg-exporter";
@@ -22,6 +22,12 @@ export default function ExportButton() {
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState<ExportTab>("mermaid");
   const [exporting, setExporting] = useState(false);
+
+  useEffect(() => {
+    const handleToggle = () => setShowModal((prev) => !prev);
+    window.addEventListener("toggle-export", handleToggle);
+    return () => window.removeEventListener("toggle-export", handleToggle);
+  }, []);
 
   const mermaidCode = canvasDataToMermaid(data);
 

--- a/src/client/components/Toolbar/ShortcutHelp.tsx
+++ b/src/client/components/Toolbar/ShortcutHelp.tsx
@@ -1,0 +1,64 @@
+const isMac = typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent);
+const MOD = isMac ? "⌘" : "Ctrl";
+
+const SHORTCUTS = [
+  { keys: `${MOD}+Z`, desc: "元に戻す" },
+  { keys: `${MOD}+Shift+Z`, desc: "やり直す" },
+  { keys: `${MOD}+D`, desc: "ノードを複製" },
+  { keys: `${MOD}+E`, desc: "エクスポート" },
+  { keys: `${MOD}+=/-`, desc: "ズームイン/アウト" },
+  { keys: `${MOD}+0`, desc: "ズームリセット" },
+  { keys: "Delete", desc: "選択を削除" },
+  { keys: "←↑→↓", desc: "ノードを移動" },
+  { keys: "Shift+←↑→↓", desc: "ノードを大きく移動" },
+  { keys: "Escape", desc: "選択解除" },
+  { keys: "?", desc: "このヘルプを表示" },
+];
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ShortcutHelp({ onClose }: Props) {
+  return (
+    <div
+      className="fixed inset-0 bg-overlay flex items-center justify-center z-50"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shortcut-help-title"
+    >
+      <div
+        className="bg-bg-panel rounded-lg border border-border w-[400px] max-h-[80vh] overflow-auto"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 id="shortcut-help-title" className="font-medium">
+            キーボードショートカット
+          </h2>
+          <button onClick={onClose} className="text-text-secondary hover:text-text">
+            &times;
+          </button>
+        </div>
+        <div className="p-4">
+          <table className="w-full text-sm">
+            <tbody>
+              {SHORTCUTS.map((s) => (
+                <tr key={s.keys} className="border-b border-border last:border-0">
+                  <td className="py-2 pr-4">
+                    <kbd className="bg-bg-hover border border-border rounded px-1.5 py-0.5 text-xs font-mono">
+                      {s.keys}
+                    </kbd>
+                  </td>
+                  <td className="py-2 text-text-secondary">{s.desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/pages/Editor.tsx
+++ b/src/client/pages/Editor.tsx
@@ -6,6 +6,7 @@ import Properties from "../components/Properties/Properties";
 import ExportButton from "../components/Toolbar/ExportButton";
 import OnlineUsers from "../components/Toolbar/OnlineUsers";
 import SaveAsTemplate from "../components/Toolbar/SaveAsTemplate";
+import ShortcutHelp from "../components/Toolbar/ShortcutHelp";
 import ThemeToggle from "../components/Toolbar/ThemeToggle";
 import VersionHistory from "../components/VersionHistory/VersionHistory";
 import { api } from "../lib/api";
@@ -35,27 +36,88 @@ export default function Editor() {
     return () => disconnect();
   }, [diagramId, setData, connect, disconnect]);
 
+  const [showShortcuts, setShowShortcuts] = useState(false);
+
   useEffect(() => {
+    const MOVE_STEP = 10;
+    const MOVE_STEP_LARGE = 50;
+    let arrowUndoPushed = false;
+    let arrowTimer: ReturnType<typeof setTimeout> | null = null;
+
     const handleKeyDown = (e: KeyboardEvent) => {
-      const tag = document.activeElement?.tagName;
+      const el = document.activeElement;
+      const tag = el?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (el instanceof HTMLElement && el.isContentEditable) return;
       const store = useCanvasStore.getState();
+      const mod = e.ctrlKey || e.metaKey;
+
+      if (e.key === "Escape") {
+        store.deselectAll();
+        setShowShortcuts(false);
+        return;
+      }
+
+      if (e.key === "?" && !mod) {
+        setShowShortcuts((prev) => !prev);
+        return;
+      }
+
       if (e.key === "Delete" || e.key === "Backspace") {
         if (store.selectedNodeId) {
           store.removeNode(store.selectedNodeId);
         } else if (store.selectedEdgeId) {
           store.removeEdge(store.selectedEdgeId);
         }
+        return;
       }
-      if (e.ctrlKey || e.metaKey) {
+
+      if (
+        ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key) &&
+        store.selectedNodeId
+      ) {
+        e.preventDefault();
+        const step = e.shiftKey ? MOVE_STEP_LARGE : MOVE_STEP;
+        const node = store.data.nodes.find((n) => n.id === store.selectedNodeId);
+        if (!node) return;
+        if (!arrowUndoPushed) {
+          store.pushUndo();
+          arrowUndoPushed = true;
+        }
+        if (arrowTimer) clearTimeout(arrowTimer);
+        arrowTimer = setTimeout(() => {
+          arrowUndoPushed = false;
+        }, 500);
+        const dx = e.key === "ArrowLeft" ? -step : e.key === "ArrowRight" ? step : 0;
+        const dy = e.key === "ArrowUp" ? -step : e.key === "ArrowDown" ? step : 0;
+        store.updateNode(node.id, { x: node.x + dx, y: node.y + dy });
+        return;
+      }
+
+      if (mod) {
         if (e.key === "z" && !e.shiftKey) {
           e.preventDefault();
           store.undo();
         } else if ((e.key === "z" && e.shiftKey) || e.key === "y") {
           e.preventDefault();
           store.redo();
-        } else if (e.key === "a") {
+        } else if (e.key === "d") {
           e.preventDefault();
+          if (store.selectedNodeId) {
+            store.duplicateNode(store.selectedNodeId);
+          }
+        } else if (e.key === "e") {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent("toggle-export"));
+        } else if (e.key === "=" || e.key === "+") {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent("canvas-zoom", { detail: "in" }));
+        } else if (e.key === "-") {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent("canvas-zoom", { detail: "out" }));
+        } else if (e.key === "0") {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent("canvas-zoom", { detail: "reset" }));
         }
       }
     };
@@ -79,6 +141,13 @@ export default function Editor() {
           <OnlineUsers />
           <ThemeToggle />
           <SaveAsTemplate />
+          <button
+            onClick={() => setShowShortcuts(true)}
+            className="text-sm text-text-secondary hover:text-text px-2 py-1 rounded-md transition-colors"
+            title="キーボードショートカット (?)"
+          >
+            ⌨
+          </button>
           <ExportButton />
         </div>
       </div>
@@ -91,6 +160,8 @@ export default function Editor() {
         </div>
         <Properties />
       </div>
+
+      {showShortcuts && <ShortcutHelp onClose={() => setShowShortcuts(false)} />}
     </div>
   );
 }

--- a/src/client/stores/canvas.ts
+++ b/src/client/stores/canvas.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { create } from "zustand";
 import type { CanvasData, CanvasEdge, CanvasGroup, CanvasNode } from "../types";
 
@@ -28,6 +29,8 @@ interface CanvasState {
   removeGroup: (id: string) => void;
   selectNode: (id: string | null) => void;
   selectEdge: (id: string | null) => void;
+  deselectAll: () => void;
+  duplicateNode: (id: string) => void;
 }
 
 export const useCanvasStore = create<CanvasState>((set, get) => ({
@@ -143,4 +146,24 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 
   selectNode: (id) => set({ selectedNodeId: id, selectedEdgeId: null }),
   selectEdge: (id) => set({ selectedEdgeId: id, selectedNodeId: null }),
+
+  deselectAll: () => set({ selectedNodeId: null, selectedEdgeId: null }),
+
+  duplicateNode: (id) => {
+    const node = get().data.nodes.find((n) => n.id === id);
+    if (!node) return;
+    get().pushUndo();
+    const newNode: CanvasNode = {
+      ...node,
+      id: nanoid(8),
+      x: node.x + 20,
+      y: node.y + 20,
+      label: `${node.label} (copy)`,
+    };
+    set((s) => ({
+      data: { ...s.data, nodes: [...s.data.nodes, newNode] },
+      selectedNodeId: newNode.id,
+      selectedEdgeId: null,
+    }));
+  },
 }));


### PR DESCRIPTION
## Summary
- Escape: 選択解除
- Ctrl+D: ノード複製
- Arrow keys: ノード移動（10px / Shift+Arrow: 50px）
- Ctrl+E: エクスポートダイアログ
- Ctrl+=/Ctrl+-: ズームイン/アウト
- Ctrl+0: ズームリセット
- ?: ショートカットヘルプ表示

## 変更内容
- canvas storeに`deselectAll`・`duplicateNode`アクション追加
- Canvas.tsxにCustomEventベースのズーム操作リスナー追加
- ExportButton.tsxにトグルイベントリスナー追加
- Editor.tsxのキーボードハンドラ拡張（contentEditable対応、Arrow undoバッチ化含む）
- ShortcutHelpコンポーネント新規作成（a11y対応: aria-modal, aria-labelledby）

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut reference modal (press `?`)
  * Duplicate selected nodes with Ctrl/Meta+D
  * Move selected nodes using arrow keys
  * Enhanced zoom controls: Ctrl/Meta+=/- to adjust, Ctrl/Meta+0 to reset view
  * Ctrl/Meta+E to toggle export modal
  * Improved keyboard handling with text input fields and Escape key support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->