### PR TITLE
スペック入力項目の追加 (#16)

### DIFF
--- a/src/client/components/Properties/Properties.tsx
+++ b/src/client/components/Properties/Properties.tsx
@@ -63,6 +63,35 @@ export default function Properties() {
               className="w-full bg-bg-hover border border-border-strong rounded-md px-2 py-1 text-sm text-text"
             />
           </div>
+          {service?.specFields && service.specFields.length > 0 && (
+            <details open className="group">
+              <summary className="text-xs font-medium text-text-secondary cursor-pointer select-none flex items-center gap-1 mb-2">
+                <span className="transition-transform group-open:rotate-90">▶</span>
+                スペック
+              </summary>
+              <div className="space-y-2">
+                {service.specFields.map((field) => (
+                  <div key={field.key}>
+                    <label className="text-xs text-text-secondary block mb-1">{field.label}</label>
+                    <input
+                      type="text"
+                      value={selectedNode.specs?.[field.key] || ""}
+                      placeholder={field.placeholder}
+                      onChange={(e) =>
+                        updateNode(selectedNode.id, {
+                          specs: {
+                            ...selectedNode.specs,
+                            [field.key]: e.target.value,
+                          },
+                        })
+                      }
+                      className="w-full bg-bg-hover border border-border-strong rounded-md px-2 py-1 text-sm text-text"
+                    />
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
           <div className="grid grid-cols-2 gap-2">
             <div>
               <label className="text-xs text-text-secondary block mb-1">X</label>

--- a/src/client/lib/aws-services.ts
+++ b/src/client/lib/aws-services.ts
@@ -1,3 +1,9 @@
+export interface SpecFieldDef {
+  key: string;
+  label: string;
+  placeholder?: string;
+}
+
 export interface AwsServiceDef {
   id: string;
   name: string;
@@ -5,6 +11,7 @@ export interface AwsServiceDef {
   color: string;
   defaultWidth: number;
   defaultHeight: number;
+  specFields?: SpecFieldDef[];
 }
 
 export type AwsCategory =
@@ -43,6 +50,12 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "instanceType", label: "インスタンスタイプ", placeholder: "t3.micro" },
+      { key: "ami", label: "AMI", placeholder: "Amazon Linux 2023" },
+      { key: "storage", label: "ストレージ", placeholder: "20 GiB gp3" },
+      { key: "os", label: "OS", placeholder: "Amazon Linux 2023" },
+    ],
   },
   {
     id: "lambda",
@@ -51,6 +64,12 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "runtime", label: "ランタイム", placeholder: "Node.js 20.x" },
+      { key: "memory", label: "メモリ", placeholder: "128 MB" },
+      { key: "timeout", label: "タイムアウト", placeholder: "30秒" },
+      { key: "architecture", label: "アーキテクチャ", placeholder: "arm64" },
+    ],
   },
   {
     id: "lightsail",
@@ -59,6 +78,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "plan", label: "プラン", placeholder: "$3.50/月" },
+      { key: "os", label: "OS", placeholder: "Amazon Linux 2" },
+    ],
   },
   {
     id: "batch",
@@ -67,6 +90,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "computeEnv", label: "コンピューティング環境", placeholder: "Fargate" },
+      { key: "vcpus", label: "vCPU", placeholder: "1" },
+      { key: "memory", label: "メモリ", placeholder: "2048 MiB" },
+    ],
   },
   {
     id: "elastic-beanstalk",
@@ -75,6 +103,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "platform", label: "プラットフォーム", placeholder: "Node.js 20" },
+      { key: "instanceType", label: "インスタンスタイプ", placeholder: "t3.small" },
+    ],
   },
   {
     id: "app-runner",
@@ -83,6 +115,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "cpu", label: "CPU", placeholder: "1 vCPU" },
+      { key: "memory", label: "メモリ", placeholder: "2 GB" },
+      { key: "source", label: "ソース", placeholder: "ECR / GitHub" },
+    ],
   },
 
   // Containers
@@ -93,6 +130,12 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "launchType", label: "起動タイプ", placeholder: "Fargate / EC2" },
+      { key: "cpu", label: "CPU", placeholder: "256" },
+      { key: "memory", label: "メモリ", placeholder: "512 MiB" },
+      { key: "desiredCount", label: "タスク数", placeholder: "2" },
+    ],
   },
   {
     id: "ecs-fargate",
@@ -101,6 +144,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "cpu", label: "CPU", placeholder: "256" },
+      { key: "memory", label: "メモリ", placeholder: "512 MiB" },
+      { key: "desiredCount", label: "タスク数", placeholder: "2" },
+    ],
   },
   {
     id: "eks",
@@ -109,6 +157,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "version", label: "バージョン", placeholder: "1.29" },
+      { key: "nodeType", label: "ノードタイプ", placeholder: "t3.medium" },
+      { key: "nodeCount", label: "ノード数", placeholder: "3" },
+    ],
   },
   {
     id: "ecr",
@@ -117,6 +170,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#ED7100",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "scanOnPush", label: "プッシュ時スキャン", placeholder: "有効" },
+      { key: "encryption", label: "暗号化", placeholder: "AES-256" },
+    ],
   },
 
   // Storage
@@ -127,6 +184,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#3F8624",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "storageClass", label: "ストレージクラス", placeholder: "Standard" },
+      { key: "versioning", label: "バージョニング", placeholder: "有効" },
+      { key: "encryption", label: "暗号化", placeholder: "SSE-S3" },
+    ],
   },
   {
     id: "efs",
@@ -135,6 +197,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#3F8624",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "performanceMode", label: "パフォーマンスモード", placeholder: "汎用" },
+      { key: "throughputMode", label: "スループットモード", placeholder: "バースト" },
+    ],
   },
   {
     id: "ebs",
@@ -143,6 +209,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#3F8624",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "volumeType", label: "ボリュームタイプ", placeholder: "gp3" },
+      { key: "size", label: "サイズ", placeholder: "100 GiB" },
+      { key: "iops", label: "IOPS", placeholder: "3000" },
+    ],
   },
   {
     id: "glacier",
@@ -151,6 +222,7 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#3F8624",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [{ key: "retrievalTier", label: "取得階層", placeholder: "Standard" }],
   },
   {
     id: "backup",
@@ -177,6 +249,12 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#2E27AD",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "engine", label: "エンジン", placeholder: "MySQL 8.0" },
+      { key: "instanceClass", label: "インスタンスクラス", placeholder: "db.t3.micro" },
+      { key: "storage", label: "ストレージ", placeholder: "20 GiB gp3" },
+      { key: "multiAz", label: "Multi-AZ", placeholder: "有効" },
+    ],
   },
   {
     id: "aurora",
@@ -185,6 +263,12 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#2E27AD",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "engine", label: "エンジン", placeholder: "Aurora MySQL 3" },
+      { key: "instanceClass", label: "インスタンスクラス", placeholder: "db.r6g.large" },
+      { key: "replicas", label: "レプリカ数", placeholder: "2" },
+      { key: "serverless", label: "Serverless v2", placeholder: "無効" },
+    ],
   },
   {
     id: "dynamodb",
@@ -193,6 +277,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#2E27AD",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "capacityMode", label: "キャパシティモード", placeholder: "オンデマンド" },
+      { key: "rcu", label: "RCU", placeholder: "5" },
+      { key: "wcu", label: "WCU", placeholder: "5" },
+    ],
   },
   {
     id: "elasticache",
@@ -201,6 +290,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#2E27AD",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "engine", label: "エンジン", placeholder: "Valkey 8" },
+      { key: "nodeType", label: "ノードタイプ", placeholder: "cache.t3.micro" },
+      { key: "nodes", label: "ノード数", placeholder: "2" },
+    ],
   },
   {
     id: "redshift",
@@ -209,6 +303,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#2E27AD",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "nodeType", label: "ノードタイプ", placeholder: "dc2.large" },
+      { key: "nodes", label: "ノード数", placeholder: "2" },
+      { key: "serverless", label: "Serverless", placeholder: "無効" },
+    ],
   },
   {
     id: "neptune",
@@ -259,6 +358,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#8C4FFF",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "scheme", label: "スキーム", placeholder: "internet-facing" },
+      { key: "listeners", label: "リスナー", placeholder: "HTTPS:443" },
+    ],
   },
   {
     id: "nlb",
@@ -267,6 +370,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#8C4FFF",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "scheme", label: "スキーム", placeholder: "internal" },
+      { key: "listeners", label: "リスナー", placeholder: "TCP:80" },
+    ],
   },
   {
     id: "cloudfront",
@@ -275,6 +382,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#8C4FFF",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "priceClass", label: "料金クラス", placeholder: "PriceClass_200" },
+      { key: "origins", label: "オリジン", placeholder: "S3 / ALB" },
+      { key: "waf", label: "WAF", placeholder: "有効" },
+    ],
   },
   {
     id: "route53",
@@ -283,6 +395,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#8C4FFF",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "domain", label: "ドメイン", placeholder: "example.com" },
+      { key: "recordType", label: "レコードタイプ", placeholder: "A / CNAME" },
+    ],
   },
   {
     id: "api-gateway",
@@ -291,6 +407,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#8C4FFF",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "type", label: "タイプ", placeholder: "REST / HTTP" },
+      { key: "auth", label: "認証", placeholder: "Cognito / IAM" },
+      { key: "stage", label: "ステージ", placeholder: "prod" },
+    ],
   },
   {
     id: "nat-gateway",
@@ -333,6 +454,11 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#E7157B",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "type", label: "タイプ", placeholder: "Standard / FIFO" },
+      { key: "visibilityTimeout", label: "可視性タイムアウト", placeholder: "30秒" },
+      { key: "retentionPeriod", label: "保持期間", placeholder: "4日" },
+    ],
   },
   {
     id: "sns",
@@ -341,6 +467,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#E7157B",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "type", label: "タイプ", placeholder: "Standard / FIFO" },
+      { key: "protocol", label: "プロトコル", placeholder: "HTTPS / SQS / Lambda" },
+    ],
   },
   {
     id: "eventbridge",
@@ -349,6 +479,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#E7157B",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "bus", label: "イベントバス", placeholder: "default" },
+      { key: "rules", label: "ルール数", placeholder: "5" },
+    ],
   },
   {
     id: "ses",
@@ -407,6 +541,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#DD344C",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "scope", label: "スコープ", placeholder: "Regional / CloudFront" },
+      { key: "rules", label: "ルール数", placeholder: "10" },
+    ],
   },
   {
     id: "acm",
@@ -423,6 +561,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#DD344C",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "pool", label: "プールタイプ", placeholder: "User Pool" },
+      { key: "mfa", label: "MFA", placeholder: "必須" },
+    ],
   },
   {
     id: "kms",
@@ -473,6 +615,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#E7157B",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "alarms", label: "アラーム数", placeholder: "5" },
+      { key: "logRetention", label: "ログ保持期間", placeholder: "30日" },
+    ],
   },
   {
     id: "cloudformation",
@@ -655,6 +801,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#01A88D",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "instanceType", label: "インスタンスタイプ", placeholder: "ml.t3.medium" },
+      { key: "framework", label: "フレームワーク", placeholder: "PyTorch 2.0" },
+    ],
   },
   {
     id: "bedrock",
@@ -663,6 +813,10 @@ export const AWS_SERVICES: AwsServiceDef[] = [
     color: "#01A88D",
     defaultWidth: 80,
     defaultHeight: 80,
+    specFields: [
+      { key: "model", label: "モデル", placeholder: "Claude Sonnet 4" },
+      { key: "throughput", label: "スループット", placeholder: "オンデマンド" },
+    ],
   },
 
   // Generic

--- a/src/client/lib/markdown-generator.ts
+++ b/src/client/lib/markdown-generator.ts
@@ -1,5 +1,5 @@
 import type { CanvasData, CanvasEdge, CanvasGroup, CanvasNode } from "../types";
-import { AWS_CATEGORIES, type AwsCategory, getServiceDef } from "./aws-services";
+import { AWS_CATEGORIES, type AwsCategory, getServiceDef, type SpecFieldDef } from "./aws-services";
 
 export function canvasDataToMarkdown(data: CanvasData): string {
   if (data.nodes.length === 0 && data.groups.length === 0) {
@@ -49,25 +49,27 @@ function appendResourceTable(lines: string[], data: CanvasData) {
 
     const catLabel = AWS_CATEGORIES[cat].label;
     lines.push(`### ${catLabel}`, "");
-    lines.push("| リソース名 | サービス | 所属グループ |");
-    lines.push("|-----------|---------|------------|");
+    lines.push("| リソース名 | サービス | 所属グループ | スペック |");
+    lines.push("|-----------|---------|------------|---------|");
 
     for (const node of nodes) {
       const def = getServiceDef(node.type);
       const serviceName = def?.name ?? node.type;
       const groupLabel = findParentGroupLabel(node, data);
-      lines.push(`| ${node.label} | ${serviceName} | ${groupLabel} |`);
+      const specStr = formatSpecs(node.specs, def?.specFields);
+      lines.push(`| ${node.label} | ${serviceName} | ${groupLabel} | ${specStr} |`);
     }
     lines.push("");
   }
 
   if (ungrouped.length > 0) {
     lines.push("### その他", "");
-    lines.push("| リソース名 | タイプ | 所属グループ |");
-    lines.push("|-----------|-------|------------|");
+    lines.push("| リソース名 | タイプ | 所属グループ | スペック |");
+    lines.push("|-----------|-------|------------|---------|");
     for (const node of ungrouped) {
       const groupLabel = findParentGroupLabel(node, data);
-      lines.push(`| ${node.label} | ${node.type} | ${groupLabel} |`);
+      const specStr = formatSpecs(node.specs);
+      lines.push(`| ${node.label} | ${node.type} | ${groupLabel} | ${specStr} |`);
     }
     lines.push("");
   }
@@ -137,6 +139,17 @@ function appendConnections(lines: string[], data: CanvasData) {
     lines.push(`| ${source} | ${target} | ${label} | ${style} |`);
   }
   lines.push("");
+}
+
+function formatSpecs(specs?: Record<string, string>, specFields?: SpecFieldDef[]): string {
+  if (!specs) return "-";
+  const pairs = Object.entries(specs)
+    .filter(([, v]) => v !== "")
+    .map(([k, v]) => {
+      const label = specFields?.find((f) => f.key === k)?.label ?? k;
+      return `${label}: ${v}`;
+    });
+  return pairs.length > 0 ? pairs.join(", ") : "-";
 }
 
 function findParentGroupLabel(node: CanvasNode, data: CanvasData): string {

--- a/src/client/lib/mermaid-generator.ts
+++ b/src/client/lib/mermaid-generator.ts
@@ -1,4 +1,13 @@
-import type { CanvasData, CanvasGroup } from "../types";
+import type { CanvasData, CanvasGroup, CanvasNode } from "../types";
+
+function formatSpecComment(node: CanvasNode, indent: string): string | null {
+  if (!node.specs) return null;
+  const pairs = Object.entries(node.specs)
+    .filter(([, v]) => v !== "")
+    .map(([k, v]) => `${k}=${v}`);
+  if (pairs.length === 0) return null;
+  return `${indent}%% specs: ${pairs.join(", ")}`;
+}
 
 export function canvasDataToMermaid(data: CanvasData): string {
   const lines: string[] = ["flowchart TD"];
@@ -27,6 +36,8 @@ export function canvasDataToMermaid(data: CanvasData): string {
       const node = data.nodes.find((n) => n.id === childId);
       if (node) {
         lines.push(`${childIndent}${sanitizeId(node.id)}["${escapeLabel(node.label)}"]`);
+        const specComment = formatSpecComment(node, childIndent);
+        if (specComment) lines.push(specComment);
       }
     }
 
@@ -35,6 +46,8 @@ export function canvasDataToMermaid(data: CanvasData): string {
     );
     for (const node of implicitChildren) {
       lines.push(`${childIndent}${sanitizeId(node.id)}["${escapeLabel(node.label)}"]`);
+      const specComment = formatSpecComment(node, childIndent);
+      if (specComment) lines.push(specComment);
     }
 
     lines.push(`${indent}end`);
@@ -47,6 +60,8 @@ export function canvasDataToMermaid(data: CanvasData): string {
   for (const node of data.nodes) {
     if (!nodesInGroups.has(node.id) && !node.group) {
       lines.push(`  ${sanitizeId(node.id)}["${escapeLabel(node.label)}"]`);
+      const specComment = formatSpecComment(node, "  ");
+      if (specComment) lines.push(specComment);
     }
   }
 

--- a/src/client/stores/canvas.ts
+++ b/src/client/stores/canvas.ts
@@ -194,6 +194,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
       x: node.x + 20,
       y: node.y + 20,
       label: `${node.label} (copy)`,
+      specs: node.specs ? { ...node.specs } : undefined,
     };
     set((s) => ({
       data: { ...s.data, nodes: [...s.data.nodes, newNode] },

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -55,6 +55,7 @@ export interface CanvasNode {
   width: number;
   height: number;
   group?: string;
+  specs?: Record<string, string>;
 }
 
 export interface CanvasEdge {


### PR DESCRIPTION
## Summary
- AWSサービスノードにスペック入力フィールドを追加（インスタンスタイプ、メモリ、エンジン等）
- Propertiesパネルに折りたたみ可能なスペック入力セクションを実装
- Mermaid/Markdownエクスポートでスペック情報を出力対応

## 変更内容
- `CanvasNode`型に`specs?: Record<string, string>`フィールド追加
- `AwsServiceDef`に`specFields?: SpecFieldDef[]`追加、主要30+サービスにスペック定義
- Properties: サービス固有のスペック入力UI（detailsタグで折りたたみ）
- Mermaid: スペックをコメント行（`%%`）として出力
- Markdown: リソース一覧テーブルに「スペック」カラム追加
- duplicateNodeでスペックもディープコピー

Closes #16

## Test plan
- [x] typecheck通過
- [x] biome check通過
- [x] テスト全件通過（11/11）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expandable "Specs" section to node properties panel with support for AWS services (EC2, Lambda, ECS, S3, RDS, ALB, SQS, WAF, CloudWatch, SageMaker, Bedrock).
  * Specs now displayed in resource tables and diagram exports.
  * Improved specs handling during node duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->