### PR TITLE
機能追加: リアルタイム共同編集 - Yjs-Canvas双方向同期

### DIFF
--- a/src/client/components/Canvas/Canvas.tsx
+++ b/src/client/components/Canvas/Canvas.tsx
@@ -2,11 +2,13 @@ import { nanoid } from "nanoid";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { AwsServiceDef, GroupTypeDef } from "../../lib/aws-services";
 import { useCanvasStore } from "../../stores/canvas";
+import { useCollaborationStore } from "../../stores/collaboration";
 import type { CanvasGroup, CanvasNode } from "../../types";
 import EdgeComponent from "./Edge";
 import EdgeCreator from "./EdgeCreator";
 import Group, { GROUP_HEADER_HEIGHT, GROUP_PADDING } from "./Group";
 import NodeComponent from "./Node";
+import RemoteCursors from "./RemoteCursors";
 
 const DEFAULT_VIEWBOX = { x: 0, y: 0, w: 1200, h: 800 };
 
@@ -71,6 +73,10 @@ export default function Canvas() {
     selectEdge,
     selectGroup,
   } = useCanvasStore();
+
+  const remoteCursors = useCollaborationStore((s) => s.remoteCursors);
+  const updateCursorPosition = useCollaborationStore((s) => s.updateCursorPosition);
+  const lastCursorBroadcast = useRef(0);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const [viewBox, setViewBox] = useState({ x: 0, y: 0, w: 1200, h: 800 });
@@ -182,6 +188,13 @@ export default function Canvas() {
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
+    const now = Date.now();
+    if (now - lastCursorBroadcast.current > 40) {
+      lastCursorBroadcast.current = now;
+      const cursorPos = svgPoint(e.clientX, e.clientY);
+      updateCursorPosition(cursorPos.x, cursorPos.y);
+    }
+
     if (edgeSourceId) {
       const pos = svgPoint(e.clientX, e.clientY);
       setEdgeEndPos(pos);
@@ -427,6 +440,8 @@ export default function Canvas() {
             onLabelChange={handleLabelChange}
           />
         ))}
+
+        <RemoteCursors cursors={remoteCursors} />
       </svg>
     </div>
   );

--- a/src/client/components/Canvas/RemoteCursors.tsx
+++ b/src/client/components/Canvas/RemoteCursors.tsx
@@ -1,10 +1,4 @@
-interface RemoteCursor {
-  clientId: number;
-  name: string;
-  color: string;
-  x: number;
-  y: number;
-}
+import type { RemoteCursor } from "../../stores/collaboration";
 
 interface RemoteCursorsProps {
   cursors: RemoteCursor[];
@@ -23,14 +17,14 @@ export default function RemoteCursors({ cursors }: RemoteCursorsProps) {
           <rect
             x={10}
             y={12}
-            width={cursor.name.length * 6 + 8}
+            width={Math.min(cursor.name.length, 12) * 6 + 8}
             height={16}
             rx={3}
             fill={cursor.color}
             opacity={0.9}
           />
           <text x={14} y={24} fill="white" fontSize={10} fontWeight="bold">
-            {cursor.name}
+            {cursor.name.length > 12 ? `${cursor.name.slice(0, 12)}…` : cursor.name}
           </text>
         </g>
       ))}

--- a/src/client/lib/yjs-canvas-binding.ts
+++ b/src/client/lib/yjs-canvas-binding.ts
@@ -1,0 +1,142 @@
+import * as Y from "yjs";
+import { useCanvasStore } from "../stores/canvas";
+import type { CanvasData, CanvasEdge, CanvasGroup, CanvasNode } from "../types";
+
+const BINDING_ORIGIN = "canvas-binding";
+
+type DeepHandler = (_events: Y.YEvent<Y.Map<string>>[], tx: Y.Transaction) => void;
+
+export class YjsCanvasBinding {
+  private doc: Y.Doc;
+  private canvasMap: Y.Map<Y.Map<string>>;
+  private nodesMap: Y.Map<string>;
+  private edgesMap: Y.Map<string>;
+  private groupsMap: Y.Map<string>;
+  private unsubscribeStore: (() => void) | null = null;
+  private remoteHandler: DeepHandler | null = null;
+  private applyingRemote = false;
+  private lastRemoteData: CanvasData | null = null;
+
+  constructor(doc: Y.Doc) {
+    this.doc = doc;
+    this.canvasMap = doc.getMap("canvas") as Y.Map<Y.Map<string>>;
+
+    this.nodesMap = this.getOrCreateSubMap("nodes");
+    this.edgesMap = this.getOrCreateSubMap("edges");
+    this.groupsMap = this.getOrCreateSubMap("groups");
+
+    this.observeRemoteChanges();
+    this.observeLocalChanges();
+  }
+
+  private getOrCreateSubMap(key: string): Y.Map<string> {
+    const existing = this.canvasMap.get(key);
+    if (existing) return existing;
+    const subMap = new Y.Map<string>();
+    this.doc.transact(() => {
+      this.canvasMap.set(key, subMap);
+    }, BINDING_ORIGIN);
+    return subMap;
+  }
+
+  private observeRemoteChanges() {
+    this.remoteHandler = (_events, tx) => {
+      if (tx.origin === BINDING_ORIGIN) return;
+      this.applyingRemote = true;
+      try {
+        const data = this.yjsToCanvasData();
+        this.lastRemoteData = data;
+        useCanvasStore.getState().applyRemoteData(data);
+      } finally {
+        this.applyingRemote = false;
+      }
+    };
+
+    this.nodesMap.observeDeep(this.remoteHandler);
+    this.edgesMap.observeDeep(this.remoteHandler);
+    this.groupsMap.observeDeep(this.remoteHandler);
+  }
+
+  private observeLocalChanges() {
+    let prevData: CanvasData | null = null;
+
+    this.unsubscribeStore = useCanvasStore.subscribe((state) => {
+      if (this.applyingRemote) return;
+      const { data } = state;
+      if (data === prevData || data === this.lastRemoteData) return;
+      prevData = data;
+      this.lastRemoteData = null;
+      this.pushToYjs(data);
+    });
+  }
+
+  pushToYjs(data: CanvasData) {
+    this.doc.transact(() => {
+      this.syncMap(this.nodesMap, data.nodes, (n) => n.id);
+      this.syncMap(this.edgesMap, data.edges, (e) => e.id);
+      this.syncMap(this.groupsMap, data.groups, (g) => g.id);
+    }, BINDING_ORIGIN);
+  }
+
+  private syncMap<T>(ymap: Y.Map<string>, items: T[], getId: (item: T) => string) {
+    const itemIds = new Set<string>();
+
+    for (const item of items) {
+      const id = getId(item);
+      itemIds.add(id);
+      const serialized = JSON.stringify(item);
+      if (ymap.get(id) !== serialized) {
+        ymap.set(id, serialized);
+      }
+    }
+
+    for (const key of ymap.keys()) {
+      if (!itemIds.has(key)) {
+        ymap.delete(key);
+      }
+    }
+  }
+
+  yjsToCanvasData(): CanvasData {
+    const nodes: CanvasNode[] = [];
+    const edges: CanvasEdge[] = [];
+    const groups: CanvasGroup[] = [];
+
+    for (const [, val] of this.nodesMap.entries()) {
+      try {
+        nodes.push(JSON.parse(val) as CanvasNode);
+      } catch {
+        // skip invalid entries
+      }
+    }
+    for (const [, val] of this.edgesMap.entries()) {
+      try {
+        edges.push(JSON.parse(val) as CanvasEdge);
+      } catch {
+        // skip
+      }
+    }
+    for (const [, val] of this.groupsMap.entries()) {
+      try {
+        groups.push(JSON.parse(val) as CanvasGroup);
+      } catch {
+        // skip
+      }
+    }
+
+    return { nodes, edges, groups };
+  }
+
+  initFromCanvasData(data: CanvasData) {
+    this.pushToYjs(data);
+  }
+
+  destroy() {
+    this.unsubscribeStore?.();
+    if (this.remoteHandler) {
+      this.nodesMap.unobserveDeep(this.remoteHandler);
+      this.edgesMap.unobserveDeep(this.remoteHandler);
+      this.groupsMap.unobserveDeep(this.remoteHandler);
+    }
+  }
+}

--- a/src/client/lib/yjs-provider.ts
+++ b/src/client/lib/yjs-provider.ts
@@ -20,10 +20,35 @@ export class DiagramProvider {
     this.diagramId = diagramId;
     this.doc = new Y.Doc();
     this.awareness = new awarenessProtocol.Awareness(this.doc);
-    this.connect();
+
+    this.doc.on("update", (update: Uint8Array, origin: unknown) => {
+      if (origin === this) return;
+      if (!this.connected || !this.ws) return;
+      const encoder = encoding.createEncoder();
+      encoding.writeVarUint(encoder, MSG_SYNC);
+      syncProtocol.writeUpdate(encoder, update);
+      this.ws.send(encoding.toUint8Array(encoder));
+    });
+
+    this.awareness.on(
+      "update",
+      ({ added, updated, removed }: { added: number[]; updated: number[]; removed: number[] }) => {
+        if (!this.connected || !this.ws) return;
+        const changedClients = [...added, ...updated, ...removed];
+        const encoder = encoding.createEncoder();
+        encoding.writeVarUint(encoder, MSG_AWARENESS);
+        encoding.writeVarUint8Array(
+          encoder,
+          awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients),
+        );
+        this.ws.send(encoding.toUint8Array(encoder));
+      },
+    );
+
+    this.connectWs();
   }
 
-  private connect() {
+  private connectWs() {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const url = `${protocol}//${window.location.host}/api/ws/diagrams/${this.diagramId}`;
     this.ws = new WebSocket(url);
@@ -82,33 +107,11 @@ export class DiagramProvider {
     this.ws.onerror = () => {
       this.ws?.close();
     };
-
-    this.doc.on("update", (update: Uint8Array, origin: unknown) => {
-      if (origin === this) return;
-      const encoder = encoding.createEncoder();
-      encoding.writeVarUint(encoder, MSG_SYNC);
-      syncProtocol.writeUpdate(encoder, update);
-      this.ws?.send(encoding.toUint8Array(encoder));
-    });
-
-    this.awareness.on(
-      "update",
-      ({ added, updated, removed }: { added: number[]; updated: number[]; removed: number[] }) => {
-        const changedClients = [...added, ...updated, ...removed];
-        const encoder = encoding.createEncoder();
-        encoding.writeVarUint(encoder, MSG_AWARENESS);
-        encoding.writeVarUint8Array(
-          encoder,
-          awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients),
-        );
-        this.ws?.send(encoding.toUint8Array(encoder));
-      },
-    );
   }
 
   private scheduleReconnect() {
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
-    this.reconnectTimer = setTimeout(() => this.connect(), 3000);
+    this.reconnectTimer = setTimeout(() => this.connectWs(), 3000);
   }
 
   isConnected() {

--- a/src/client/pages/Editor.tsx
+++ b/src/client/pages/Editor.tsx
@@ -26,17 +26,32 @@ export default function Editor() {
 
   useEffect(() => {
     if (!diagramId) return;
+    connect(diagramId);
+
     api.get<Diagram>(`/diagrams/${diagramId}`).then((d) => {
       setDiagram(d);
       if (d.canvas_data) {
         try {
-          setData(JSON.parse(d.canvas_data) as CanvasData);
+          const canvasData = JSON.parse(d.canvas_data) as CanvasData;
+          const { binding } = useCollaborationStore.getState();
+          if (binding) {
+            const existing = binding.yjsToCanvasData();
+            const isEmpty =
+              existing.nodes.length === 0 &&
+              existing.edges.length === 0 &&
+              existing.groups.length === 0;
+            if (isEmpty) {
+              setData(canvasData);
+              binding.initFromCanvasData(canvasData);
+            }
+          } else {
+            setData(canvasData);
+          }
         } catch {
           // ignore invalid JSON
         }
       }
     });
-    connect(diagramId);
     return () => disconnect();
   }, [diagramId, setData, connect, disconnect]);
 

--- a/src/client/stores/canvas.ts
+++ b/src/client/stores/canvas.ts
@@ -17,6 +17,7 @@ interface CanvasState {
   redoStack: CanvasData[];
 
   setData: (data: CanvasData) => void;
+  applyRemoteData: (data: CanvasData) => void;
   pushUndo: () => void;
   undo: () => void;
   redo: () => void;
@@ -47,6 +48,8 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   redoStack: [],
 
   setData: (data) => set({ data, undoStack: [], redoStack: [] }),
+
+  applyRemoteData: (data) => set({ data }),
 
   pushUndo: () =>
     set((s) => ({

--- a/src/client/stores/collaboration.ts
+++ b/src/client/stores/collaboration.ts
@@ -1,12 +1,25 @@
 import { create } from "zustand";
+import { YjsCanvasBinding } from "../lib/yjs-canvas-binding";
 import { DiagramProvider } from "../lib/yjs-provider";
+import { useAuthStore } from "./auth";
+
+export interface RemoteCursor {
+  clientId: number;
+  name: string;
+  color: string;
+  x: number;
+  y: number;
+}
 
 interface CollaborationState {
   provider: DiagramProvider | null;
+  binding: YjsCanvasBinding | null;
   connected: boolean;
   onlineUsers: Array<{ clientId: number; name: string; color: string }>;
+  remoteCursors: RemoteCursor[];
   connect: (diagramId: string) => void;
   disconnect: () => void;
+  updateCursorPosition: (x: number, y: number) => void;
 }
 
 const USER_COLORS = [
@@ -22,42 +35,84 @@ const USER_COLORS = [
 
 export const useCollaborationStore = create<CollaborationState>((set, get) => ({
   provider: null,
+  binding: null,
   connected: false,
   onlineUsers: [],
+  remoteCursors: [],
 
   connect: (diagramId: string) => {
     const existing = get().provider;
     if (existing) existing.destroy();
+    const existingBinding = get().binding;
+    if (existingBinding) existingBinding.destroy();
 
     const provider = new DiagramProvider(diagramId);
+    const binding = new YjsCanvasBinding(provider.doc);
 
     provider.onStatusChange(() => {
-      set({ connected: provider.isConnected() });
+      const connected = provider.isConnected();
+      set({ connected });
+
+      if (connected) {
+        const user = useAuthStore.getState().user;
+        const color = USER_COLORS[provider.doc.clientID % USER_COLORS.length];
+        provider.awareness.setLocalState({
+          user: {
+            name: user?.name || user?.email || "Anonymous",
+            color,
+          },
+          cursor: null,
+        });
+      }
     });
 
     provider.awareness.on("change", () => {
       const states = provider.awareness.getStates();
       const users: Array<{ clientId: number; name: string; color: string }> = [];
+      const cursors: RemoteCursor[] = [];
+
       states.forEach((state, clientId) => {
-        if (clientId !== provider.doc.clientID && state.user) {
+        if (clientId === provider.doc.clientID) return;
+        if (state.user) {
+          const color = state.user.color || USER_COLORS[clientId % USER_COLORS.length];
           users.push({
             clientId,
             name: state.user.name || "Unknown",
-            color: state.user.color || USER_COLORS[clientId % USER_COLORS.length],
+            color,
           });
+          if (state.cursor) {
+            cursors.push({
+              clientId,
+              name: state.user.name || "Unknown",
+              color,
+              x: state.cursor.x,
+              y: state.cursor.y,
+            });
+          }
         }
       });
-      set({ onlineUsers: users });
+      set({ onlineUsers: users, remoteCursors: cursors });
     });
 
-    set({ provider, connected: false });
+    set({ provider, binding, connected: false });
   },
 
   disconnect: () => {
+    const { provider, binding } = get();
+    if (binding) binding.destroy();
+    if (provider) provider.destroy();
+    set({
+      provider: null,
+      binding: null,
+      connected: false,
+      onlineUsers: [],
+      remoteCursors: [],
+    });
+  },
+
+  updateCursorPosition: (x: number, y: number) => {
     const { provider } = get();
-    if (provider) {
-      provider.destroy();
-      set({ provider: null, connected: false, onlineUsers: [] });
-    }
+    if (!provider) return;
+    provider.awareness.setLocalStateField("cursor", { x, y });
   },
 }));

--- a/src/worker/durable-objects/diagram-room.ts
+++ b/src/worker/durable-objects/diagram-room.ts
@@ -158,22 +158,25 @@ export class DiagramRoom implements DurableObject {
 
     const state = Y.encodeStateAsUpdate(this.doc);
 
-    const nodesMap = this.doc.getMap("canvas");
+    const canvasMap = this.doc.getMap("canvas");
     let canvasData: string | null = null;
-    const mermaidCode: string | null = null;
 
-    if (nodesMap.size > 0) {
+    if (canvasMap.size > 0) {
       try {
-        canvasData = JSON.stringify(nodesMap.toJSON());
+        const raw = canvasMap.toJSON() as Record<string, Record<string, string>>;
+        const nodes = raw.nodes ? Object.values(raw.nodes).map((v) => JSON.parse(v)) : [];
+        const edges = raw.edges ? Object.values(raw.edges).map((v) => JSON.parse(v)) : [];
+        const groups = raw.groups ? Object.values(raw.groups).map((v) => JSON.parse(v)) : [];
+        canvasData = JSON.stringify({ nodes, edges, groups });
       } catch {
         // ignore serialization errors
       }
     }
 
     await this.env.DB.prepare(
-      `UPDATE diagrams SET yjs_state = ?, canvas_data = ?, mermaid_code = ?, updated_at = datetime('now') WHERE id = ?`,
+      `UPDATE diagrams SET yjs_state = ?, canvas_data = ?, updated_at = datetime('now') WHERE id = ?`,
     )
-      .bind(state, canvasData, mermaidCode, this.diagramId)
+      .bind(state, canvasData, this.diagramId)
       .run();
 
     this.dirty = false;


### PR DESCRIPTION
## Summary
- Yjs Y.DocとZustand Canvas Storeの双方向バインディングによるリアルタイム共同編集を実装
- Awarenessプロトコルでユーザー名・色・カーソル位置をbroadcast、RemoteCursorsでSVGキャンバス上に他ユーザーカーソルを表示
- DiagramRoom (Durable Object) のflushロジックをネストされたY.Map構造に対応、mermaid_code null上書き防止

## 変更内容
- **新規**: `src/client/lib/yjs-canvas-binding.ts` - Canvas Store ↔ Yjs双方向同期ブリッジ
- **変更**: `src/client/stores/collaboration.ts` - binding初期化、awareness state設定、リモートカーソル管理
- **変更**: `src/client/stores/canvas.ts` - `applyRemoteData()`追加（undo/redo保持）
- **変更**: `src/client/lib/yjs-provider.ts` - リスナー重複登録修正（コンストラクタに移動）
- **変更**: `src/client/pages/Editor.tsx` - Yjs同期と初期データロードのレースコンディション対応
- **変更**: `src/client/components/Canvas/Canvas.tsx` - RemoteCursors統合、カーソルbroadcast（40msスロットリング）
- **変更**: `src/client/components/Canvas/RemoteCursors.tsx` - 型共通化、名前表示の最大文字数制限
- **変更**: `src/worker/durable-objects/diagram-room.ts` - map→array変換、mermaid_code上書き防止

Closes #25

## Test plan
- [ ] typecheck + biome check + vitest 全通過確認済み
- [ ] 2ブラウザタブで同一diagramを開き、ノード追加・移動・削除がリアルタイム同期されることを確認
- [ ] 他ユーザーのカーソルがSVGキャンバス上に表示されることを確認
- [ ] OnlineUsersにアバターが表示されることを確認
- [ ] 一方のタブを閉じても他方が正常に動作し続けることを確認
- [ ] undo/redoがローカル操作のみに作用し、リモート変更でスタックがクリアされないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time remote cursor visibility to see where collaborators are positioned on the canvas
  * Implemented automatic canvas synchronization between collaborators to keep data in sync
  * Optimized cursor broadcasting with throttling to improve collaboration responsiveness

* **Improvements**
  * Enhanced remote cursor labels with truncated names for better visual clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->